### PR TITLE
make this plugin browser friendly with optional fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,65 +1,71 @@
-const glob = require('glob');
-const isGlob = require('is-glob');
-const Path = require('path');
-const fs = require('fs');
-const identifierfy = require('identifierfy');
+const glob = require("glob");
+const isGlob = require("is-glob");
+const Path = require("path");
+const identifierfy = require("identifierfy");
 
 /* Checks the type of the import specifiers. Throws an error if any specifier isn't a default specifier. */
 function assertImportDefaultSpecifier(path, specifiers) {
-  let hasError = specifiers.length === 0 || specifiers.length > 1
+  let hasError = specifiers.length === 0 || specifiers.length > 1;
   if (!hasError) {
     for (const { type } of specifiers) {
-      if (type !== 'ImportDefaultSpecifier') {
-        hasError = true
-        break
+      if (type !== "ImportDefaultSpecifier") {
+        hasError = true;
+        break;
       }
     }
   }
   if (hasError) {
-    throw path.buildCodeFrameError('Can only import the default export from a glob pattern');
+    throw path.buildCodeFrameError(
+      "Can only import the default export from a glob pattern"
+    );
   }
 }
 
 /* Read a sibling package.json file and return the name property from it. */
-function readPackageName(index) {
-  let pkgPath = Path.join(Path.dirname(index), "package.json")
-  if (!fs.existsSync(pkgPath)) {
-    return
+function readPackageName(index, fs) {
+  let pkgPath = Path.join(Path.dirname(index), "package.json");
+  try {
+    let pkg = fs.readFileSync(pkgPath, "utf8");
+    return JSON.parse(pkg).name;
+  } catch (e) {
+    return Path.join(
+      `@${Path.basename(Path.dirname(Path.dirname(index)))}`,
+      Path.basename(Path.dirname(index))
+    );
   }
-  let pkg = fs.readFileSync(pkgPath, 'utf8');
-  return JSON.parse(pkg).name;
 }
 
 // From novemberborn/babel-plugin-import-glob
 function memberify(subpath) {
-  const pieces = subpath.split(Path.sep)
-  const prefixReservedWords = pieces.length === 1
-  const ids = []
+  const pieces = subpath.split(Path.sep);
+  const prefixReservedWords = pieces.length === 1;
+  const ids = [];
   for (let index = 0; index < pieces.length; index++) {
-    const name = pieces[index]
+    const name = pieces[index];
     const id = identifierfy(name, {
       prefixReservedWords,
       prefixInvalidIdentifiers: index === 0
-    })
+    });
     if (id === null) {
-      return null
+      return null;
     }
-    ids.push(id)
+    ids.push(id);
   }
-  return ids.join('$')
+  return ids.join("$");
 }
 
-function generateNameForImport(file, baseDir) {
-  const name = memberify(Path.basename(Path.dirname(file)))
-  let pakage = readPackageName(Path.resolve(baseDir, file));
+function generateNameForImport(file, baseDir, fs) {
+  const name = memberify(Path.basename(Path.dirname(file)));
+  let pakage = readPackageName(Path.resolve(baseDir, file), fs);
 
   if (!pakage) {
-    pakage = name
+    pakage = name;
   }
 
   return {
-    name, pakage
-  }
+    name,
+    pakage
+  };
 }
 
 module.exports = function importGlobMetaPlugin(babel) {
@@ -68,104 +74,107 @@ module.exports = function importGlobMetaPlugin(babel) {
   return {
     visitor: {
       ImportDeclaration(path, state) {
-        const { node: { specifiers, source } } = path
+        const {
+          node: { specifiers, source }
+        } = path;
 
-        const importPath = source.value
-        const currentFilePath = state.file.opts.filename
-        const baseDir = Path.resolve(Path.dirname(currentFilePath))
+        const { fs } = state.opts;
+        const importPath = source.value;
+        const currentFilePath = state.file.opts.filename;
+        const baseDir = Path.resolve(Path.dirname(currentFilePath));
 
         // If this is not a local import, don't do anything
-        if (importPath[0] !== '.' && importPath[0] !== '/') return
+        if (importPath[0] !== "." && importPath[0] !== "/") return;
 
         // If the import specifier doesn't contain a glob pattern, don't do anything
-        if (!isGlob(importPath)) return
+        if (!isGlob(importPath)) return;
 
-        assertImportDefaultSpecifier(path, specifiers)
+        assertImportDefaultSpecifier(path, specifiers);
 
         // Find file matches based on the glob pattern
-        let files = glob.sync(
-          Path.join(baseDir, importPath),
-          {
-            cwd: baseDir,
-            nodir: true,
-            strict: true
-          }
-        )
+        let files = glob.sync(Path.join(baseDir, importPath), {
+          cwd: baseDir,
+          nodir: true,
+          strict: true
+        });
 
         // Return let modules = [] on no matches
         if (!files) {
           path.replaceWith(
             t.variableDeclaration("let", [
               t.variableDeclarator(
-                t.identifier(specifiers[0].local.name), t.arrayExpression([])
+                t.identifier(specifiers[0].local.name),
+                t.arrayExpression([])
               )
             ])
-          )
-          return
+          );
+          return;
         }
 
         // Compute relative paths
-        files = files.map(file => {
-          rel = Path.relative(baseDir, file)
+        files = files.map((file) => {
+          rel = Path.relative(baseDir, file);
           if (rel.charAt(0) != ".") {
-            rel = `./${rel}`
+            rel = `./${rel}`;
           }
-          return rel
-        })
+          return rel;
+        });
 
-        let dict = []
-        files.map(file => {
-          const { name, pakage } = generateNameForImport(file, baseDir)
+        let dict = [];
+        files.map((file) => {
+          const { name, pakage } = generateNameForImport(file, baseDir, fs);
           // Generate an unique placeholder for the import specifier name
-          const placeholder = path.scope.generateUid('_ig')
+          const placeholder = path.scope.generateUid("_ig");
           dict.push({
-            name, file, placeholder, pakage
-          })
-        })
+            name,
+            file,
+            placeholder,
+            pakage
+          });
+        });
 
-        let importRemappings = [], assignRemappings = [];
-        dict.map(item => {
+        let importRemappings = [],
+          assignRemappings = [];
+        dict.map((item) => {
           // Add import with placeholder name for specifier and relative path as source
           importRemappings.push(
             t.importDeclaration(
-              [
-                t.importDefaultSpecifier(t.identifier(item.placeholder))
-              ],
+              [t.importDefaultSpecifier(t.identifier(item.placeholder))],
               t.stringLiteral(item.file)
             )
-          )
+          );
           // Add an object with name, value, path and package of the imported object
           assignRemappings.push(
-            t.objectExpression(
-              [
-                t.objectProperty(
-                  t.stringLiteral("name"), t.stringLiteral(item.name)
-                ),
-                t.objectProperty(
-                  t.stringLiteral("value"), t.identifier(item.placeholder)
-                ),
-                t.objectProperty(
-                  t.stringLiteral("path"), t.stringLiteral(item.file)
-                ),
-                t.objectProperty(
-                  t.stringLiteral("package"), t.stringLiteral(item.pakage)
-                ),
-              ]
-            )
-          )
+            t.objectExpression([
+              t.objectProperty(
+                t.stringLiteral("name"),
+                t.stringLiteral(item.name)
+              ),
+              t.objectProperty(
+                t.stringLiteral("value"),
+                t.identifier(item.placeholder)
+              ),
+              t.objectProperty(
+                t.stringLiteral("path"),
+                t.stringLiteral(item.file)
+              ),
+              t.objectProperty(
+                t.stringLiteral("package"),
+                t.stringLiteral(item.pakage)
+              )
+            ])
+          );
         });
 
         let assignMap = t.variableDeclaration("let", [
-          t.variableDeclarator(t.identifier(specifiers[0].local.name), t.arrayExpression(
-            assignRemappings
-          ))
-        ])
+          t.variableDeclarator(
+            t.identifier(specifiers[0].local.name),
+            t.arrayExpression(assignRemappings)
+          )
+        ]);
 
         // Replace the path with the new imports and variable assignment
-        path.replaceWithMultiple([
-          ...importRemappings,
-          assignMap
-        ])
+        path.replaceWithMultiple([...importRemappings, assignMap]);
       }
     }
   };

--- a/tests/__snapshots__/index.spec.js.snap
+++ b/tests/__snapshots__/index.spec.js.snap
@@ -29,4 +29,33 @@ let options = [{
 }];"
 `;
 
+exports[`gracefully resolves package names when fs isn't available (i.e. in a browser) 1`] = `
+"import _ig from \\"./module-B/index.js\\";
+import _ig2 from \\"./moduleA/index.js\\";
+let modules = [{
+  \\"name\\": \\"moduleB\\",
+  \\"value\\": _ig,
+  \\"path\\": \\"./module-B/index.js\\",
+  \\"package\\": \\"@fixtures/module-B\\"
+}, {
+  \\"name\\": \\"moduleA\\",
+  \\"value\\": _ig2,
+  \\"path\\": \\"./moduleA/index.js\\",
+  \\"package\\": \\"@fixtures/moduleA\\"
+}];
+import _ig3 from \\"./module-B/options.js\\";
+import _ig4 from \\"./moduleA/options.js\\";
+let options = [{
+  \\"name\\": \\"moduleB\\",
+  \\"value\\": _ig3,
+  \\"path\\": \\"./module-B/options.js\\",
+  \\"package\\": \\"@fixtures/module-B\\"
+}, {
+  \\"name\\": \\"moduleA\\",
+  \\"value\\": _ig4,
+  \\"path\\": \\"./moduleA/options.js\\",
+  \\"package\\": \\"@fixtures/moduleA\\"
+}];"
+`;
+
 exports[`returns empty array on zero matches 1`] = `"let modules = [];"`;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,30 +1,49 @@
-const babel = require('babel-core');
-const plugin = require('../');
-const path = require('path');
-const fs = require('fs');
+const babel = require("babel-core");
+const plugin = require("../");
+const path = require("path");
+const fs = require("fs");
 
 function loadFixture(name) {
   const fixture = path.join(__dirname, "fixtures", name);
   return {
-    content: fs.readFileSync(fixture, 'utf8'),
+    content: fs.readFileSync(fixture, "utf8"),
     filename: fixture
-  }
+  };
 }
 
-it('converts default glob imports', () => {
+it("converts default glob imports", () => {
   const { content, filename } = loadFixture("index.js");
-  const { code } = babel.transform(content, { plugins: [plugin], filename });
+  const { code } = babel.transform(content, {
+    plugins: [[plugin, { fs: fs }]],
+    filename
+  });
   expect(code).toMatchSnapshot();
 });
 
-it('throws error on named glob imports', () => {
+it("throws error on named glob imports", () => {
   const { content, filename } = loadFixture("index.bad.js");
-  expect(() => babel.transform(content, { plugins: [plugin], filename }))
-    .toThrow('Can only import the default export from a glob pattern');
+  expect(() =>
+    babel.transform(content, {
+      plugins: [[plugin, { fs: fs }]],
+      filename
+    })
+  ).toThrow("Can only import the default export from a glob pattern");
 });
 
-it('returns empty array on zero matches', () => {
+it("returns empty array on zero matches", () => {
   const { content, filename } = loadFixture("index.empty.js");
-  const { code } = babel.transform(content, { plugins: [plugin], filename });
+  const { code } = babel.transform(content, {
+    plugins: [[plugin, { fs: fs }]],
+    filename
+  });
+  expect(code).toMatchSnapshot();
+});
+
+it("gracefully resolves package names when fs isn't available (i.e. in a browser)", () => {
+  const { content, filename } = loadFixture("index.js");
+  const { code } = babel.transform(content, {
+    plugins: [[plugin, { fs: undefined }]],
+    filename
+  });
   expect(code).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR makes the `fs` dependency optional and uses babel plugin options for accessing it. With this change this plugin can be run in environments where an `fs` implementation doesn't exist or most importantly where one can be replaced with an alternative (i.e. ligthning-fs).

Dependency Injection :smiley: 